### PR TITLE
feat(framework): add script to generate tests

### DIFF
--- a/codegen.py
+++ b/codegen.py
@@ -8,11 +8,13 @@ import os
 
 """
 This script is used to generate Bao Project tests code.
-It searches for C source files with 'BAO_TEST' markers and creates corresponding test functions.
+It searches for C source files with 'BAO_TEST' markers and creates
+corresponding test functions.
 """
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Script to parse tests sources and generate tests code')
+    parser = argparse.ArgumentParser(description='Script to parse tests \
+                                     sourcesand generate tests code')
 
     parser.add_argument("-dir", "--base_dir",
                         help="Base directory of the tests directory",
@@ -37,7 +39,8 @@ def get_srcs_list(base_dir):
 
 def code_header():
     code = "/*" + "\n"
-    code += "* Copyright (c) Bao Project and Contributors. All rights reserved" + "\n"
+    code += "* Copyright (c) Bao Project and Contributors. "
+    code += "All rights reserved" + "\n"
     code += "*" + "\n"
     code += "* SPDX-License-Identifier: Apache-2.0" + "\n"
     code += "*/" + "\n"

--- a/codegen.py
+++ b/codegen.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Bao Project and Contributors. All rights reserved
+
+import numpy as np
+import argparse
+import glob
+import os
+
+"""
+This script is used to generate Bao Project tests code.
+It searches for C source files with 'BAO_TEST' markers and creates corresponding test functions.
+"""
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Script to parse tests sources and generate tests code')
+
+    parser.add_argument("-dir", "--base_dir",
+                        help="Base directory of the tests directory",
+                        default="./")
+
+    parser.add_argument("-o", "--out_code",
+                        help="Output file to place the tests code",
+                        default="./")
+
+    args = parser.parse_args()
+    return args
+
+
+def get_srcs_list(base_dir):
+    c_srcs = []
+    for root, dirs, files in os.walk(base_dir):
+        for file in files:
+            if file.endswith(".c"):
+                c_srcs.append(os.path.join(root, file))
+    return c_srcs
+
+
+def code_header():
+    code = "/*" + "\n"
+    code += "* Copyright (c) Bao Project and Contributors. All rights reserved" + "\n"
+    code += "*" + "\n"
+    code += "* SPDX-License-Identifier: Apache-2.0" + "\n"
+    code += "*/" + "\n"
+    return code
+
+
+def code_includes():
+    code = "#include \"testf.h\"" + "\n"
+    code += "#include <stdio.h>" + "\n"
+    code += "#include <string.h>" + "\n"
+    return code
+
+
+def code_variables():
+    code = "unsigned int testframework_tests;" + "\n"
+    code += "unsigned int testframework_fails;" + "\n"
+    return code
+
+
+def generate_defines(base_dir):
+    c_files = get_srcs_list(base_dir)
+    tests_list = {}
+    code = ""
+    for file in c_files:
+        with open(file, "r") as f:
+            file_code = f.readlines()
+
+        for line in file_code:
+            if "BAO_TEST" in line:
+                clear_line = line.replace(" ", "")
+                clear_line = clear_line.replace("BAO_TEST(", "")
+                clear_line = clear_line.replace(")", "")
+                clear_line = clear_line.replace("\n", "")
+                clear_line = clear_line.replace("{", "")
+                suite_name = clear_line.split(",")[0]
+                test_name = clear_line.split(",")[1]
+
+                if suite_name in tests_list:
+                    tests_list[suite_name].append(test_name)
+
+                else:
+                    tests_list[suite_name] = [test_name]
+
+    for suite in tests_list.keys():
+        for test in tests_list[suite]:
+            code += "\t#if defined " + test + " || " + suite + "\n"
+            code += "\tentry_test_" + suite + "_" + test + "();" + "\n"
+            code += "\t#endif" + "\n" + "\n"
+
+    return code
+
+
+def code_functions(base_dir):
+    code = "void testf_entry(void)" + "\n"
+    code += "{" + "\n"
+
+    code += generate_defines(base_dir)
+
+    code += "\tif (testframework_tests > 0) {" + "\n"
+    code += "\t\tBAO_LOG_TESTS();" + "\n"
+    code += "\t} else {" + "\n"
+    code += "\t\tBAO_INFO_TAG();" + "\n"
+    code += "\t\tprintf(\"No tests were executed!\\n\");" + "\n"
+    code += "\t}" + "\n"
+    code += "\treturn;" + "\n"
+    code += "}" + "\n"
+    return code
+
+
+def generate_code(base_dir):
+    code = ""
+    code += code_header() + "\n"
+    code += code_includes() + "\n"
+    code += code_variables() + "\n"
+    code += code_functions(base_dir) + "\n"
+    return code
+
+
+if __name__ == '__main__':
+    tool_args = parse_args()
+    print("base_dir: ", tool_args.base_dir)
+    code = generate_code(tool_args.base_dir)
+
+    with open(tool_args.out_code, "w") as f:
+        f.write(code)
+
+    print("Successfully generated bao tests code")

--- a/template.c
+++ b/template.c
@@ -1,0 +1,28 @@
+/*
+* Copyright (c) Bao Project and Contributors. All rights reserved
+*
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+#include "testf.h"
+#include <stdio.h>
+#include <string.h>
+
+unsigned int testframework_tests;
+unsigned int testframework_fails;
+
+
+void testf_entry(void)
+{
+    // codegen.py section begin
+
+    // codegen.py section end
+
+    if (testframework_tests > 0) {
+		BAO_LOG_TESTS();
+	} else {
+		BAO_INFO_TAG();
+		printf("No tests were executed!\n");
+	}
+	return;
+}


### PR DESCRIPTION
## PR Description

This PR introduces a Python script that automates the generation of tests for the test framework. The need for this script arose because the project can contain multiple C code files with different tests, and users may want to run only a subset of these tests. Hence, this script has been developed to create a set of macros that enable users to selectively choose which tests to run.

To use the script, follow the code below:

```bash
python3 codegen.py -d tests -o bao-tests/src/testf_entry.c
```

When running the script with the specified arguments, it will search for test files in the tests directory and generate macros to handle test selection. The output will be written to bao-tests/src/testf_entry.c.

Please review this PR and provide your feedback.

## Type of change

- **feat**: introduces a new functionality
  - Logical unit: test generation automation script

## Checklist:

- [x] The changes generate no new warnings when building the project. If so, I have justified above.
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.