### PR TITLE
fix(template): Update the macros on template.c

### DIFF
--- a/template.c
+++ b/template.c
@@ -19,9 +19,9 @@ void testf_entry(void)
     // codegen.py section end
 
     if (testframework_tests > 0) {
-		BAO_LOG_TESTS();
+		LOG_TESTS();
 	} else {
-		BAO_INFO_TAG();
+		INFO_TAG();
 		printf("No tests were executed!\n");
 	}
 	return;


### PR DESCRIPTION
## PR Description

This pull request addresses a minor bug in the `template.c` file utilized by `codegen.py`. 
- In `template.c`, deprecated macros `BAO_LOG_TESTS();` and `BAO_INFO_TAG();` have been replaced with `LOG_TESTS();` and `INFO_TAG();`, respectively.

### Type of change

- **fix**: bug fix
  - Logical unit: template.c

## Checklist:
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.
