### PR TITLE
fix: Remove deprecated BAO_ tag from testf_assert.h

### DIFF
--- a/src/inc/testf_assert.h
+++ b/src/inc/testf_assert.h
@@ -22,7 +22,7 @@
                 (*failures)++;                                  \
                 intra_fails++;                                  \
                 if (intra_fails == 1)                           \
-                    BAO_LOG_FAILURE();                          \
+                    LOG_FAILURE();                              \
                 if (TESTF_LOG_LEVEL > 1) {                      \
                     printf("    Index: %d\n", i);               \
                 }                                               \
@@ -40,7 +40,7 @@
         }                                                       \
         if (intra_fails == 0) {                                 \
             (*failures)++;                                      \
-            BAO_LOG_FAILURE();                                  \
+            LOG_FAILURE();                                      \
         }                                                       \
     } while (0)
 
@@ -48,7 +48,7 @@
     do {                          \
         if (!(x op y)) {          \
             (*failures)++;        \
-            BAO_LOG_FAILURE();    \
+            LOG_FAILURE();        \
         }                         \
     } while (0)
 
@@ -56,7 +56,7 @@
 
 #define TESTF_FAIL(message) \
     (*failures)++;          \
-    BAO_LOG_FAILURE();      \
+    LOG_FAILURE();          \
     printf("    Message: %s\n", message);
 
 #endif // TESTF_ASSERT_H


### PR DESCRIPTION
## PR Description

This pull request addresses a minor bug in the `testf_assert.h` file. 
- In `testf_assert.c`, deprecated macros `BAO_LOG_FAILURE();`  have been replaced with `LOG_FAILURE();`.

### Type of change

- **fix**: bug fix
  - Logical unit: testf_assert.h

## Checklist:
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.
