### PR TITLE
feat(framework): add config and build capabilities to test framework

### DIFF
--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -5,12 +5,12 @@
 Test framework main file
 """
 import argparse
-import constants as cons
-from pydevicetree import Devicetree
 import os
 import sys
-import psutil
 import subprocess
+import psutil
+import constants as cons
+from pydevicetree import Devicetree
 
 PARSER = argparse.ArgumentParser(description="Bao Testing Framework")
 PARSER.add_argument("--dts_path", help="Path to .dts configuration file")
@@ -50,10 +50,13 @@ def run_command_in_terminal(command):
     Args:
         command (str): The command to execute.
     """
+    # pylint: disable=R1732
     terminal_process = subprocess.Popen(
         ['/bin/bash', '-c', command],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE
     )
+    # pylint: enable=R1732
+
     return terminal_process
 
 def terminate_children_processes(parent_process):

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -77,3 +77,32 @@ if __name__ == '__main__':
     RUN_CMD += "-o ./src/testf_weak.c"
     os.system(RUN_CMD)
     os.chdir(CURR_DIR)
+
+    print(cons.BLUE_TEXT + "Running nix build..." + cons.RESET_COLOR)
+    BUILD_CMD = 'nix-build ../../' + test_config['nix_file']
+    list_suites = test_config['suites'].split()
+    list_tests = test_config['tests'].split()
+    BUILD_CMD += " --argstr platform " + test_config['platform']
+    if len(list_suites):
+        BUILD_CMD += " --argstr list_suites \""
+        for suit in list_suites:
+            BUILD_CMD += suit + " "
+        BUILD_CMD = BUILD_CMD[:-1] + "\""
+    if len(list_tests):
+        BUILD_CMD += " --argstr list_tests \""
+        for suit in list_tests:
+            BUILD_CMD += suit + " "
+        BUILD_CMD = BUILD_CMD[:-1] + "\""
+
+    print(BUILD_CMD)
+    res = os.system(BUILD_CMD)
+    if res==0:
+        print(cons.GREEN_TEXT +
+            "nix build successfully completed..." +
+            cons.RESET_COLOR)
+
+    else:
+        print(cons.RED_TEXT +
+               "nix build failed..." +
+               cons.RESET_COLOR)
+        sys.exit(-1)

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -6,9 +6,61 @@ Test framework main file
 """
 import argparse
 import constants as cons
+from pydevicetree import Devicetree 
 
 PARSER = argparse.ArgumentParser(description="Bao Testing Framework")
+PARSER.add_argument("--dts_path", help="Path to .dts configuration file")
+
+test_config = {
+    'nix_file': '',
+    'suites': '',
+    'tests': '',
+    'tests_configs': {
+        'log_level': ''
+    }
+}
+
+def parse_dts_file(file_path):
+    """
+    Parse a DTS (Device Tree Source) file and extract relevant information.
+
+    Args:
+        file_path (str): The path to the DTS configuration file.
+    """
+    tree = Devicetree.parseFile(file_path)
+    test_config['platform'] = \
+        tree.children[0].properties[0].values[0]
+    test_config['nix_file'] = \
+        tree.children[0].children[0].children[0].properties[0].values[0]
+    test_config['suites'] = \
+        tree.children[0].children[0].children[0].properties[1].values[0]
+    test_config['tests'] = \
+        tree.children[0].children[0].children[0].properties[2].values[0]
+    test_config['tests_configs']['log_level'] = \
+        tree.children[0].children[0].children[0].properties[2].values[0]
 
 if __name__ == '__main__':
 
     print(cons.BLUE_TEXT + "Framework init..." + cons.RESET_COLOR)
+    print(cons.BLUE_TEXT +
+          "Framework init..." +
+          cons.RESET_COLOR)
+
+    args = PARSER.parse_args()
+
+    print(cons.BLUE_TEXT +
+          "Reading config.dts..." +
+          cons.RESET_COLOR)
+
+    dts_path = args.dts_path
+    print("config.dts file: " + dts_path)
+
+    if args.dts_path is None:
+        print(cons.RED_TEXT +
+              "Error: Please provide the --dts_path argument." +
+              cons.RESET_COLOR)
+    else:
+        dts_path = args.dts_path
+
+    parse_dts_file(dts_path)
+    print(cons.GREEN_TEXT + "config.dts successfully read!" + cons.RESET_COLOR)

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -6,7 +6,9 @@ Test framework main file
 """
 import argparse
 import constants as cons
-from pydevicetree import Devicetree 
+from pydevicetree import Devicetree
+import os
+import sys
 
 PARSER = argparse.ArgumentParser(description="Bao Testing Framework")
 PARSER.add_argument("--dts_path", help="Path to .dts configuration file")
@@ -64,3 +66,14 @@ if __name__ == '__main__':
 
     parse_dts_file(dts_path)
     print(cons.GREEN_TEXT + "config.dts successfully read!" + cons.RESET_COLOR)
+
+    print(cons.BLUE_TEXT +
+          "Creating tests source file..." +
+          cons.RESET_COLOR)
+    CURR_DIR = os.getcwd()
+    print("CURR_DIR: " + CURR_DIR)
+    os.chdir("../")
+    RUN_CMD = "python3 codegen.py -dir ../src/ "
+    RUN_CMD += "-o ./src/testf_weak.c"
+    os.system(RUN_CMD)
+    os.chdir(CURR_DIR)


### PR DESCRIPTION
## PR Description

This pull request implements configuration and build capabilities into the test framework.

### Types of Changes

- **feat**: Configuration Parsing
  - Logical Unit: `test_framework.py`

The commit [ae1c283](https://github.com/bao-project/bao-tests/commit/ae1c28384964b7553ad7cfaeeaad2d0995912fd7) introduces the ability to parse a `.dts` file, enabling the selection of test configurations, definition of Nix build recipes, and specifying test verbosity.

- **feat**: System Build (Codegen Integration)
  - Logical Unit: `test_framework.py`

The commit [3d495f3](https://github.com/bao-project/bao-tests/commit/3d495f39621b3ee66b3d0284d63a7125c1c9725c) introduces the integration of the `codegen` Python script, as introduced in [a88f836](https://github.com/bao-project/bao-tests/commit/a88f836452a0c586f2449df0be4df7ff82263677).

- **feat**: System Build (Nix Build)
  - Logical Unit: `test_framework.py`

The commit [b1669ff](https://github.com/bao-project/bao-tests/commit/b1669ff321bc4a06362d314dd23a923edda5b9e4) enables the use of Nix scripts for building the system under test. Additionally, commit [0f7dff8](https://github.com/bao-project/bao-tests/commit/0f7dff8858071d74bc54f05c1fb327e3e2c916c8) introduces the capability to launch the target platform, currently limited to the qemu platform.

## Checklist:
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.