### PR TITLE
fix(results): update nix-build results parsing

### DIFF
--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -114,7 +114,7 @@ def get_file_path(filename):
 
     for directory in result_directories:
         dir_path = os.path.join(os.getcwd(), directory)
-        for root, files in os.walk(dir_path):
+        for root, _, files in os.walk(dir_path):
             if filename in files:
                 return os.path.join(root, filename)
 


### PR DESCRIPTION
# PR Summary:

This pull request implements a minor adjustment to the parsing of bao-nix results within the framework. Following the invocation of the nix build system, the framework is responsible for locating the binary file of the Bao hypervisor. However, the earlier version of the test framework was unable to process the parsing of results containing solely subdirectories. This update addresses that limitation by enabling the parsing of result folders comprising files, folders, or a combination of both.


```diff
- for root, files in os.walk(dir_path): 
+ for root, _, files in os.walk(dir_path):
```

Please provide feedback on this change.