### PR TITLE
fix(parse): update tests and suites lists parsing

### DIFF
--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -261,14 +261,20 @@ if __name__ == '__main__':
 
     if len(list_suites):
         BUILD_CMD += " --argstr list_suites \""
-        for suit in list_suites:
-            BUILD_CMD += suit + " "
-        BUILD_CMD = BUILD_CMD[:-1] + "\""
+        for index, suit in enumerate(list_suites):
+            BUILD_CMD += suit
+            if index < len(list_suites) - 1:
+                BUILD_CMD += r"\ "
+        BUILD_CMD += "\""
+
     if len(list_tests):
         BUILD_CMD += " --argstr list_tests \""
-        for suit in list_tests:
-            BUILD_CMD += suit + " "
-        BUILD_CMD = BUILD_CMD[:-1] + "\""
+        for index, test in enumerate(list_tests):
+            BUILD_CMD += test
+            if index < len(list_tests) - 1:
+                BUILD_CMD += r"\ "
+        BUILD_CMD += "\""
+
 
     print(BUILD_CMD)
     res = os.system(BUILD_CMD)


### PR DESCRIPTION
This PR addresses a minor issue related to parsing the list of tests and suites in the config.dts files. Previously, there was a bug where parsing multiple suites and/or tests was not functioning correctly. For example, consider the following config.dts file:

```dts
/dts-v1/;
/ {
    platform = "qemu-aarch64-virt";
    log_echo = <1>;

    test_config {
        recipe_test {
            nix_file = "default.nix";
            suites = "SUCCESS_SUITE FAIL_SUITE";
            tests = "";
            log_level = "0";
        };
    };
};
```

Running the Nix build system with the command:
```sh
nix-build default.nix --argstr platform qemu-aarch64-virt --argstr list_suites "SUCCESS_SUITE FAIL_SUITE"
```
would result in the following error:
```sh
make: *** No rule to make target 'FAIL_SUITE'.  Stop.
```

With the changes introduced in this pull request, the corrected build command now looks like:
```sh
nix-build default.nix --argstr platform qemu-aarch64-virt --argstr list_suites "SUCCESS_SUITE\ FAIL_SUITE"
```

Please review and provide any comments or suggestions.