### PR TITLE
fix(framework): include log level setup

### DIFF
--- a/framework/connection.py
+++ b/framework/connection.py
@@ -114,18 +114,16 @@ def listener(ser_port, echo):
                 new_line = new_line.replace(old, new)
             res_log.append(new_line)
 
-            if (b"[INFO]" in res) and (echo):
-                print(new_line, end="")
+            if "[TESTF-C]" in new_line:
+                cons.TEST_RESULTS = new_line
 
             if stop_event.is_set():
                 break
 
-        for line in res_log:
-            #print("line: " + line)
+        for line in reversed(res_log):
             if "[TESTF-C]" in line:
-                if echo:
-                    print(line)
                 cons.TEST_RESULTS = line
+                break
 
         if echo == "full":
             full_echo_log(res_log)

--- a/framework/connection.py
+++ b/framework/connection.py
@@ -56,6 +56,19 @@ def connect_to_platform_port(ports_list, echo):
     for thread in threads:
         thread.join()
 
+def full_echo_log(serial_results):
+    """
+    Print each line in the serial results.
+
+    Args:
+        serial_results (list): A list of lines got from serial communication.
+
+    Returns:
+        None
+    """
+    for line in serial_results:
+        print(line, end="")
+    thread_finished.set()
 def listener(ser_port, echo):
     """
     Listener to receive test results
@@ -91,6 +104,10 @@ def listener(ser_port, echo):
                 if echo:
                     print(line)
                 cons.TEST_RESULTS = line
+
+        if echo == "full":
+            full_echo_log(res_log)
+
                 thread_finished.set()
 
     print(cons.BLUE_TEXT +

--- a/framework/connection.py
+++ b/framework/connection.py
@@ -82,9 +82,9 @@ def tf_echo_log(serial_results):
     """
     is_tf_section = False
     for line in serial_results:
-        if "[TESTF] START" in line:
+        if cons.C_TAG + " START" in line:
             is_tf_section = True
-        elif "[TESTF] END" in line:
+        elif cons.C_TAG + " END" in line:
             is_tf_section = False
             print(line, end="")
         if is_tf_section:
@@ -107,7 +107,7 @@ def listener(ser_port, echo):
         res = b""
         res_log = []
 
-        while not (res.endswith(b"\r\n") and b"[TESTF] END" in res):
+        while not (res.endswith(b"\r\n") and (cons.C_TAG + " END").encode('utf-8') in res):
             res = ser_port.readline()
             new_line = res.decode(errors='ignore')
             for old, new in replacements:

--- a/framework/connection.py
+++ b/framework/connection.py
@@ -69,6 +69,28 @@ def full_echo_log(serial_results):
     for line in serial_results:
         print(line, end="")
     thread_finished.set()
+
+def tf_echo_log(serial_results):
+    """
+    Filter and print serial results within the TF section.
+
+    Args:
+        serial_results (list): A list of lines got from serial communication.
+
+    Returns:
+        None
+    """
+    is_tf_section = False
+    for line in serial_results:
+        if "[TESTF] START" in line:
+            is_tf_section = True
+        elif "[TESTF] END" in line:
+            is_tf_section = False
+            print(line, end="")
+        if is_tf_section:
+            print(line, end="")
+    thread_finished.set()
+
 def listener(ser_port, echo):
     """
     Listener to receive test results
@@ -107,6 +129,9 @@ def listener(ser_port, echo):
 
         if echo == "full":
             full_echo_log(res_log)
+
+        elif echo == "tf":
+            tf_echo_log(res_log)
 
                 thread_finished.set()
 

--- a/framework/connection.py
+++ b/framework/connection.py
@@ -133,7 +133,8 @@ def listener(ser_port, echo):
         elif echo == "tf":
             tf_echo_log(res_log)
 
-                thread_finished.set()
+        elif echo == "none":
+            thread_finished.set()
 
     print(cons.BLUE_TEXT +
           "Closing connection to " +

--- a/framework/connection.py
+++ b/framework/connection.py
@@ -30,7 +30,7 @@ def diff_ports(ports_init, ports_end):
     return diff
 
 
-def connect_to_platform_port(ports_list, log_echo):
+def connect_to_platform_port(ports_list, echo):
     """
     Establishes connections to multiple serial ports concurrently and starts a
     listener thread for each port.
@@ -44,7 +44,7 @@ def connect_to_platform_port(ports_list, log_echo):
 
     for port in ports_list:
         ser_port = open_connection(port)
-        new_thread = threading.Thread(target=listener, args=[ser_port, log_echo])
+        new_thread = threading.Thread(target=listener, args=[ser_port, echo])
         threads.append(new_thread)
 
     for thread in threads:
@@ -56,7 +56,7 @@ def connect_to_platform_port(ports_list, log_echo):
     for thread in threads:
         thread.join()
 
-def listener(ser_port, log_echo):
+def listener(ser_port, echo):
     """
     Listener to receive test results
     """
@@ -78,7 +78,7 @@ def listener(ser_port, log_echo):
                 new_line = new_line.replace(old, new)
             res_log.append(new_line)
 
-            if (b"[INFO]" in res) and (log_echo):
+            if (b"[INFO]" in res) and (echo):
                 print(new_line, end="")
 
             if stop_event.is_set():
@@ -87,7 +87,7 @@ def listener(ser_port, log_echo):
         for line in res_log:
             #print("line: " + line)
             if "[TESTF-C]" in line:
-                if log_echo:
+                if echo:
                     print(line)
                 cons.TEST_RESULTS = line
                 thread_finished.set()

--- a/framework/connection.py
+++ b/framework/connection.py
@@ -71,7 +71,8 @@ def listener(ser_port, echo):
     while not stop_event.is_set():
         res = b""
         res_log = []
-        while not (res.endswith(b"\r\n") and b"[TESTF-C]" in res):
+
+        while not (res.endswith(b"\r\n") and b"[TESTF] END" in res):
             res = ser_port.readline()
             new_line = res.decode(errors='ignore')
             for old, new in replacements:

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -16,7 +16,7 @@ import connection
 
 test_config = {
     'platform': '',
-    'log_echo': '',
+    'echo': '',
     'nix_file': '',
     'suites': '',
     'tests': '',
@@ -61,7 +61,7 @@ def parse_dts_file(file_path):
         tree.children[0].properties[0].values[0]
 
     try:
-        test_config['log_echo'] = \
+        test_config['echo'] = \
             tree.children[0].properties[1].values[0]
     except (IndexError, AttributeError):
         test_config['log_echo'] = 0
@@ -161,7 +161,7 @@ def deploy_test(platform):
         # Find the difference between the initial and final pts ports
         diff_ports = connection.diff_ports(initial_pts_ports, final_pts_ports)
 
-        connection.connect_to_platform_port(diff_ports, test_config['log_echo'])
+        connection.connect_to_platform_port(diff_ports, test_config['echo'])
         terminate_children_processes(process)
 
 def clean_output():

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -20,9 +20,7 @@ test_config = {
     'nix_file': '',
     'suites': '',
     'tests': '',
-    'tests_configs': {
-        'log_level': ''
-    }
+    'log_level': ''
 }
 
 def parse_args():
@@ -72,8 +70,8 @@ def parse_dts_file(file_path):
         tree.children[0].children[0].children[0].properties[1].values[0]
     test_config['tests'] = \
         tree.children[0].children[0].children[0].properties[2].values[0]
-    test_config['tests_configs']['log_level'] = \
-        tree.children[0].children[0].children[0].properties[2].values[0]
+    test_config['log_level'] = \
+        tree.children[0].children[0].children[0].properties[3].values[0]
 
 def run_command_in_terminal(command):
     """
@@ -259,6 +257,8 @@ if __name__ == '__main__':
     list_suites = test_config['suites'].split()
     list_tests = test_config['tests'].split()
     BUILD_CMD += " --argstr platform " + test_config['platform']
+    BUILD_CMD += " --argstr log_level " + test_config['log_level']
+
     if len(list_suites):
         BUILD_CMD += " --argstr list_suites \""
         for suit in list_suites:

--- a/src/inc/testf.h
+++ b/src/inc/testf.h
@@ -49,6 +49,11 @@ extern unsigned int testframework_start, testframework_end;
     printf("[TESTF] START\n"); \
     COLOR_RESET();
 
+#define END_TAG()            \
+    YELLOW();                \
+    printf("[TESTF] END\n"); \
+    COLOR_RESET();
+
 #if (TESTF_LOG_LEVEL > 0)
 #define LOG_FAILURE()                                                 \
     do {                                                              \

--- a/src/inc/testf.h
+++ b/src/inc/testf.h
@@ -44,15 +44,9 @@ extern unsigned int testframework_start, testframework_end;
     printf("[SUCCESS] "); \
     COLOR_RESET();
 
-#define START_TAG()            \
-    YELLOW();                  \
-    printf("[TESTF] START\n"); \
-    COLOR_RESET();
+#define START_TAG() printf("[TESTF-C] START\n");
 
-#define END_TAG()            \
-    YELLOW();                \
-    printf("[TESTF] END\n"); \
-    COLOR_RESET();
+#define END_TAG()   printf("[TESTF-C] END\n");
 
 #if (TESTF_LOG_LEVEL > 0)
 #define LOG_FAILURE()                                                 \

--- a/src/inc/testf.h
+++ b/src/inc/testf.h
@@ -44,6 +44,11 @@ extern unsigned int testframework_start, testframework_end;
     printf("[SUCCESS] "); \
     COLOR_RESET();
 
+#define START_TAG()            \
+    YELLOW();                  \
+    printf("[TESTF] START\n"); \
+    COLOR_RESET();
+
 #if (TESTF_LOG_LEVEL > 0)
 #define LOG_FAILURE()                                                 \
     do {                                                              \

--- a/src/template.c
+++ b/src/template.c
@@ -13,6 +13,7 @@ unsigned int testframework_fails;
 
 void testf_entry(void)
 {
+    START_TAG();
     // codegen.py section begin
 
     // codegen.py section end
@@ -23,5 +24,6 @@ void testf_entry(void)
         INFO_TAG();
         printf("No tests were executed!\n");
     }
+    END_TAG();
     return;
 }


### PR DESCRIPTION
# PR Summary

This pull request introduces a new feature (echo mode), along with a crucial bug fix in the logging behavior of the Python framework. 

## Echo mode
The echo mode provides three options:

- **Full echo (`echo=full`):** Prints all logging information.
- **None echo (`echo=none`):** Suppresses printing of the entire log.
- **Test Framework echo (`echo=tf`):** Prints only the log associated with the test framework.

## Log Level Fix
Additionally, this PR addresses a bug where the log level defined in the device tree was not being correctly passed to the `nix-build` command for the Python framework.

## Configuration in Device Tree Source (DTS)

To enable more granular control over the logging behavior, two fields are now used in the config.dts file:

1. **log_level (`log_level=0, 1, 2`):**
   - Defines the logging produced by the C code of the framework, and ranges from 0 (simplest) to 2 (most comprehensive).

2. **echo (`echo=full, none, tf`):**
   - Determines the Echo mode behavior as described above.

Please review the changes and share your thoughts and suggestions.