### PR TITLE
fix(.gitmodules): update CI url to clone via ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ci"]
 	path = ci
-	url = https://github.com/bao-project/bao-ci.git
+	url = git@github.com:bao-project/bao-ci.git


### PR DESCRIPTION
This PR updates the .gitmodules file to use the ssh connection rather than the https.