### PR TITLE
fix(config): improve logging setup and tests selection in the framework

### DIFF
--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -259,21 +259,26 @@ if __name__ == '__main__':
 
     print(cons.BLUE_TEXT + "Running nix build..." + cons.RESET_COLOR)
     BUILD_CMD = 'nix-build ../../' + test_config['nix_file']
-    list_suites = test_config['suites']
-    list_tests = test_config['tests']
+    LIST_SUITES = test_config['suites']
+    LIST_TESTS = test_config['tests']
     BUILD_CMD += " --argstr platform " + test_config['platform']
     BUILD_CMD += " --argstr log_level " + str(args.log_level)
 
-    if len(list_suites):
+    if LIST_SUITES:
         BUILD_CMD += " --argstr list_suites \""
-        for suit in list_suites:
-            BUILD_CMD += suit + " "
-        BUILD_CMD = BUILD_CMD[:-1] + "\""
-    if len(list_tests):
+        for index, suit in enumerate(LIST_SUITES):
+            BUILD_CMD += suit
+            if index < len(LIST_SUITES) - 1:
+                BUILD_CMD += r"\ "
+        BUILD_CMD += "\""
+
+    if LIST_TESTS:
         BUILD_CMD += " --argstr list_tests \""
-        for suit in list_tests:
-            BUILD_CMD += suit + " "
-        BUILD_CMD = BUILD_CMD[:-1] + "\""
+        for index, test in enumerate(LIST_TESTS):
+            BUILD_CMD += test
+            if index < len(LIST_TESTS) - 1:
+                BUILD_CMD += r"\ "
+        BUILD_CMD += "\""
 
     print(BUILD_CMD)
     res = os.system(BUILD_CMD)

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -16,7 +16,6 @@ import connection
 
 test_config = {
     'platform': '',
-    'echo': '',
     'nix_file': '',
     'suites': '',
     'tests': '',
@@ -44,6 +43,13 @@ def parse_args():
     parser.add_argument("-clean", action='store_true',
                     help="Clean output directory")
 
+    parser.add_argument("-echo", "--echo",
+                    help="Allows to define the filtering of the framework: "
+                         "full - does not filter any information"
+                         "tf - filters logging not produced by the framework"
+                         "none - filter every logging",
+                    default="tf")
+
     input_args = parser.parse_args()
     return input_args
 
@@ -57,12 +63,6 @@ def parse_dts_file(file_path):
     tree = Devicetree.parseFile(file_path)
     test_config['platform'] = \
         tree.children[0].properties[0].values[0]
-
-    try:
-        test_config['echo'] = \
-            tree.children[0].properties[1].values[0]
-    except (IndexError, AttributeError):
-        test_config['log_echo'] = 0
 
     test_config['nix_file'] = \
         tree.children[0].children[0].children[0].properties[0].values[0]
@@ -159,7 +159,7 @@ def deploy_test(platform):
         # Find the difference between the initial and final pts ports
         diff_ports = connection.diff_ports(initial_pts_ports, final_pts_ports)
 
-        connection.connect_to_platform_port(diff_ports, test_config['echo'])
+        connection.connect_to_platform_port(diff_ports, args.echo)
         terminate_children_processes(process)
 
 def clean_output():

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -19,7 +19,6 @@ test_config = {
     'nix_file': '',
     'suites': '',
     'tests': '',
-    'log_level': ''
 }
 
 def parse_args():
@@ -50,6 +49,14 @@ def parse_args():
                          "none - filter every logging",
                     default="tf")
 
+    parser.add_argument("-log_level", "--log_level",
+                    help="Allows to define the amount of information produced"
+                         "by the framework: "
+                         "0 - only logs the final report, "
+                         "1 - logs failed tests and the final report, "
+                         "2 - logs all test results and the final report",
+                    default=0)
+
     input_args = parser.parse_args()
     return input_args
 
@@ -70,8 +77,6 @@ def parse_dts_file(file_path):
         tree.children[0].children[0].children[0].properties[1].values[0]
     test_config['tests'] = \
         tree.children[0].children[0].children[0].properties[2].values[0]
-    test_config['log_level'] = \
-        tree.children[0].children[0].children[0].properties[3].values[0]
 
 def run_command_in_terminal(command):
     """
@@ -257,7 +262,7 @@ if __name__ == '__main__':
     list_suites = test_config['suites'].split()
     list_tests = test_config['tests'].split()
     BUILD_CMD += " --argstr platform " + test_config['platform']
-    BUILD_CMD += " --argstr log_level " + test_config['log_level']
+    BUILD_CMD += " --argstr log_level " + str(args.log_level)
 
     if len(list_suites):
         BUILD_CMD += " --argstr list_suites \""

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -74,9 +74,9 @@ def parse_dts_file(file_path):
     test_config['nix_file'] = \
         tree.children[0].children[0].children[0].properties[0].values[0]
     test_config['suites'] = \
-        tree.children[0].children[0].children[0].properties[1].values[0]
+        tree.children[0].children[0].children[0].properties[1].values
     test_config['tests'] = \
-        tree.children[0].children[0].children[0].properties[2].values[0]
+        tree.children[0].children[0].children[0].properties[2].values
 
 def run_command_in_terminal(command):
     """
@@ -259,8 +259,8 @@ if __name__ == '__main__':
 
     print(cons.BLUE_TEXT + "Running nix build..." + cons.RESET_COLOR)
     BUILD_CMD = 'nix-build ../../' + test_config['nix_file']
-    list_suites = test_config['suites'].split()
-    list_tests = test_config['tests'].split()
+    list_suites = test_config['suites']
+    list_tests = test_config['tests']
     BUILD_CMD += " --argstr platform " + test_config['platform']
     BUILD_CMD += " --argstr log_level " + str(args.log_level)
 


### PR DESCRIPTION
# PR summary

This PR introduces two major changes:

1. Enable the definition of an array of strings for both the list of suites and tests (commit 01df22023602fa0f54124b83f6fe8bbcf94de691).
2. Remove the "echo" and "log_level" configurations from config.dts; configuration is now performed via the command line (commits bfd1cfa5c0dfc95c844f3e2274931f04c5ecbc37 and 47b26b7f29c327fbe915b9c88ada34561e501563).

## Old config.dts format:
```dts
/dts-v1/;
/ {
    platform = "qemu-aarch64-virt";
    echo = "full";  // fulll, tf, none

    test_config {
        recipe_test {
            nix_file = "default.nix";
            suites = "SUITE_1 SUITE_2";
            tests = "";
            log_level = "1"; //0, 1, 2
        };
    };
};
```
## New config.dts format:
```dts
/dts-v1/;
/ {
    platform = "qemu-aarch64-virt";

    test_config {
        recipe_test {
            nix_file = "default.nix";
            suites = "SUITE_1", "SUITE_2";
            tests = "";
        };
    };
};
```

## Old python framework execution command:
```console
python3 test_framework.py\
  -dts_path $ROOT_DIR/tests/configs/mix_suite.dts\
  -bao_test_src_path $ROOT_DIR/bao-tests/src\
  -tests_src_path $ROOT_DIR/tests/src\
```

## New python framework execution command:
```console
python3 test_framework.py\
  -dts_path $ROOT_DIR/tests/configs/mix_suite.dts\
  -bao_test_src_path $ROOT_DIR/bao-tests/src\
  -tests_src_path $ROOT_DIR/tests/src\
  -echo=full\
  -log_level=1
```


