### PR TITLE
update(gitignore): Add framework output to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .clang-format
 bao_test.c
 testf_entry.c
+framework/output/*


### PR DESCRIPTION
## PR description

Several outputs from the python tool were not being ignored. 
This PR adds the folder output to the .gitignore file.