### PR TITLE
Feat(remove dts): Remove the the use of DTS files

### DIFF
--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -52,6 +52,14 @@ def parse_args():
                          "2 - logs all test results and the final report",
                     default=0)
 
+    parser.add_argument("-recipe", "--recipe",
+                    help="Path to the .nix recipe file",
+                    default="../../recipes/single-baremetal/default.nix")
+
+    parser.add_argument("-platform", "--platform",
+                    help="Used define the target platform",
+                    default=" ")
+
     input_args = parser.parse_args()
     return input_args
 

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -226,6 +226,22 @@ if __name__ == '__main__':
     os.system(RUN_CMD)
 
     print(cons.BLUE_TEXT + "Running nix build..." + cons.RESET_COLOR)
+
+    if args.platform is None:
+        print(cons.RED_TEXT +
+        "Error: Please provide a --platform." +
+        cons.RESET_COLOR)
+    else:
+        platfrm = args.platform
+
+    if args.recipe is None:
+        print(cons.RED_TEXT +
+        "Error: Please provide the --recipe argument." +
+        cons.RESET_COLOR)
+    else:
+        recipe = args.recipe
+        print("Recipe .nix file: " + recipe)
+
     BUILD_CMD = 'nix-build ../../' + test_config['nix_file']
     BUILD_CMD += " --argstr platform " + test_config['platform']
     BUILD_CMD += " --argstr log_level " + str(args.log_level)

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -242,8 +242,8 @@ if __name__ == '__main__':
         recipe = args.recipe
         print("Recipe .nix file: " + recipe)
 
-    BUILD_CMD = 'nix-build ../../' + test_config['nix_file']
-    BUILD_CMD += " --argstr platform " + test_config['platform']
+    BUILD_CMD = 'nix-build ' + recipe
+    BUILD_CMD += " --argstr platform " + platfrm
     BUILD_CMD += " --argstr log_level " + str(args.log_level)
 
     print(BUILD_CMD)
@@ -262,4 +262,4 @@ if __name__ == '__main__':
     move_results_to_output()
 
     print(cons.BLUE_TEXT + "Launching QEMU..." + cons.RESET_COLOR)
-    deploy_test(test_config['platform'])
+    deploy_test(platfrm)

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -11,7 +11,6 @@ import sys
 import subprocess
 import psutil
 import constants as cons
-from pydevicetree import Devicetree
 import connection
 
 test_config = {
@@ -26,10 +25,6 @@ def parse_args():
     Parse python script arguments.
     """
     parser = argparse.ArgumentParser(description="Bao Testing Framework")
-
-    parser.add_argument("-dts_path", "--dts_path",
-                        help="Path to .dts configuration file",
-                        default="../../configs/config.dts")
 
     parser.add_argument("-bao_test_src_path", "--bao_test_src_path",
                         help="Path to bao-test /src dir",
@@ -59,24 +54,6 @@ def parse_args():
 
     input_args = parser.parse_args()
     return input_args
-
-def parse_dts_file(file_path):
-    """
-    Parse a DTS (Device Tree Source) file and extract relevant information.
-
-    Args:
-        file_path (str): The path to the DTS configuration file.
-    """
-    tree = Devicetree.parseFile(file_path)
-    test_config['platform'] = \
-        tree.children[0].properties[0].values[0]
-
-    test_config['nix_file'] = \
-        tree.children[0].children[0].children[0].properties[0].values[0]
-    test_config['suites'] = \
-        tree.children[0].children[0].children[0].properties[1].values
-    test_config['tests'] = \
-        tree.children[0].children[0].children[0].properties[2].values
 
 def run_command_in_terminal(command):
     """
@@ -231,23 +208,6 @@ if __name__ == '__main__':
         sys.exit(-1)
 
     print(cons.BLUE_TEXT +
-          "Reading config.dts..." +
-          cons.RESET_COLOR)
-
-    dts_path = args.dts_path
-    print("config.dts file: " + dts_path)
-
-    if args.dts_path is None:
-        print(cons.RED_TEXT +
-              "Error: Please provide the --dts_path argument." +
-              cons.RESET_COLOR)
-    else:
-        dts_path = args.dts_path
-
-    parse_dts_file(dts_path)
-    print(cons.GREEN_TEXT + "config.dts successfully read!" + cons.RESET_COLOR)
-
-    print(cons.BLUE_TEXT +
           "Creating tests source file..." +
           cons.RESET_COLOR)
 
@@ -259,26 +219,8 @@ if __name__ == '__main__':
 
     print(cons.BLUE_TEXT + "Running nix build..." + cons.RESET_COLOR)
     BUILD_CMD = 'nix-build ../../' + test_config['nix_file']
-    LIST_SUITES = test_config['suites']
-    LIST_TESTS = test_config['tests']
     BUILD_CMD += " --argstr platform " + test_config['platform']
     BUILD_CMD += " --argstr log_level " + str(args.log_level)
-
-    if LIST_SUITES:
-        BUILD_CMD += " --argstr list_suites \""
-        for index, suit in enumerate(LIST_SUITES):
-            BUILD_CMD += suit
-            if index < len(LIST_SUITES) - 1:
-                BUILD_CMD += r"\ "
-        BUILD_CMD += "\""
-
-    if LIST_TESTS:
-        BUILD_CMD += " --argstr list_tests \""
-        for index, test in enumerate(LIST_TESTS):
-            BUILD_CMD += test
-            if index < len(LIST_TESTS) - 1:
-                BUILD_CMD += r"\ "
-        BUILD_CMD += "\""
 
     print(BUILD_CMD)
     res = os.system(BUILD_CMD)


### PR DESCRIPTION
## PR Description

DTS files were previously used to define the following variables: tests, suites, platform, nix recipe, log and echo levels. Since the latter two variables were moved to command line options. The use of an additional file just to define effectively 3 variables, was starting to become overkill. Furthermore, in order to specify different tests and suites for different guests, would require increasing the complexity of the DTS file.

As such, we opted to move the definition of which test and suite runs on which guest to the nix recipe. Both nix recipe and platform are now passed to the framework via command line. This concentrates all configurations in a single file/recipe. 

The expected command to execute the framework is:
`python3 test_framework.py -recipe PATH/TO/RECIPE.nix -platform SUPPORTED_PLATFORM`

And an example of a guest definition in a nix recipe:

```
    guests = [
          (callPackage (../../bao-nix/pkgs/guest/baremetal-remote-tf.nix)
                  { 
                    inherit system-cfg;
                    inherit toolchain;
                    guest_name = "baremetal";
                    list_tests = "";
                    list_suites = "BASIC";
                    inherit log_level;            
                  }
          )
      ];
```


