### PR TITLE
feat(framework): include qemu launch check

### DIFF
--- a/framework/launch/qemu-aarch64-virt.sh
+++ b/framework/launch/qemu-aarch64-virt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure -p qemu -i bash
+#!nix-shell --pure -p unixtools.netstat -p qemu -i bash
 
 # Check if a version argument is provided
 if [ -z "$2" ]; then
@@ -10,11 +10,20 @@ fi
 qemu_platform="$1"
 flash_bin_path="$2"
 bao_bin_path="$3"
-# -s -S -nographic\
-qemu-system-"$qemu_platform" -nographic\
+
+if netstat -tuln | grep ":5555 " &>/dev/null; then
+    exit -1
+fi
+
+qemu_stderr=$(mktemp)
+
+qemu-system-"$qemu_platform" -nographic \
     -M virt,secure=on,virtualization=on,gic-version=3 \
-   -cpu cortex-a53 -smp 4 -m 4G\
-   -bios $flash_bin_path \
-   -device loader,file="$bao_bin_path",addr=0x50000000,force-raw=on\
-   -device virtio-net-device,netdev=net0 -netdev user,id=net0,hostfwd=tcp:127.0.0.1:5555-:22\
-   -serial pty
+    -cpu cortex-a53 -smp 4 -m 4G \
+    -bios "$flash_bin_path" \
+    -device loader,file="$bao_bin_path",addr=0x50000000,force-raw=on \
+    -device virtio-net-device,netdev=net0 -netdev user,id=net0,hostfwd=tcp:127.0.0.1:5555-:22 \
+    -serial pty 2> "$qemu_stderr"
+
+rm "$qemu_stderr"
+exit 0

--- a/framework/launch/qemu-riscv64-virt.sh
+++ b/framework/launch/qemu-riscv64-virt.sh
@@ -10,7 +10,13 @@ fi
 qemu_platform="$1"
 opensbi_elf_path="$2"
 bao_bin_path="$3"
-# -s -S -nographic\
+
+if netstat -tuln | grep ":5555 " &>/dev/null; then
+    exit -1
+fi
+
+qemu_stderr=$(mktemp)
+
 qemu-system-riscv64 -nographic \
     -M virt -cpu rv64 -m 4G -smp 4 \
     -bios $opensbi_elf_path \
@@ -18,4 +24,7 @@ qemu-system-riscv64 -nographic \
     -device virtio-net-device,netdev=net0 \
     -netdev user,id=net0,net=192.168.42.0/24,hostfwd=tcp:127.0.0.1:5555-:22 \
     -device virtio-serial-device -chardev pty,id=serial3 -device virtconsole,chardev=serial3 \
-    -serial pty
+    -serial pty 2> "$qemu_stderr"
+    
+rm "$qemu_stderr"
+exit 0

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -154,6 +154,11 @@ def deploy_test(platform):
     # from the initial ports; this retrieves the pts ports opened by QEMU
     while final_pts_ports == initial_pts_ports:
         final_pts_ports = connection.scan_pts_ports()
+        if process.poll():
+            print(cons.RED_TEXT +
+                f"Error launching QEMU (exited with code {process.returncode})" +
+                cons.RESET_COLOR)
+            sys.exit(-1)
 
     # Find the difference between the initial and final pts ports
     diff_ports = connection.diff_ports(initial_pts_ports, final_pts_ports)


### PR DESCRIPTION
# PR Description

This PR implements improvements related to detecting QEMU launch failures within the framework. Three commits are included:
1. the addition of QEMU launch failure logging
2. updates to the launch scripts for the RISCV64 QEMU instance
3. updates to the launch scripts for the AArch64 QEMU instance

Previously, QEMU launch failures would occur silently, potentially due to conflicts with existing instances, leading to errors like ":22: Could not set up host forwarding rule 'tcp:127.0.0.1:5555-:22'". With these changes, the framework can now identify such failures and properly abort the test launch. 

Please provide feedback on these changes.