### PR TITLE
fix(framework): remove codegen call from python framework

### DIFF
--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -229,15 +229,6 @@ if __name__ == '__main__':
             cons.RESET_COLOR)
         sys.exit(-1)
 
-    print(cons.BLUE_TEXT +
-          "Creating tests source file..." +
-          cons.RESET_COLOR)
-
-    bao_test_src = args.bao_test_src_path
-    tests_src = args.tests_src_path
-    RUN_CMD = "python3 codegen.py -dir " + tests_src + " "
-    RUN_CMD += "-o " + bao_test_src + "/testf_entry.c"
-    os.system(RUN_CMD)
 
     print(cons.BLUE_TEXT + "Running nix build..." + cons.RESET_COLOR)
 


### PR DESCRIPTION
This PR introduces a fix to the Python framework. Previously, the codegen was invoked by the Python framework. However, it is no longer required, as the codegen is now handled by the guest Nix recipes.