### PR TITLE
fix(framework): ensure script runs correctly from any directory

### DIFF
--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -13,6 +13,9 @@ import psutil
 import constants as cons
 import connection
 
+script_dir = os.path.dirname(os.path.abspath(__file__))
+os.chdir(script_dir)
+
 test_config = {
     'platform': '',
     'nix_file': '',


### PR DESCRIPTION
This PR introduces changes to enable the test framework to be executed from the bao-tests/framework directory.