### PR TITLE
feat(platforms): add support to qemu platforms

### DIFF
--- a/framework/launch/qemu-aarch64-virt.sh
+++ b/framework/launch/qemu-aarch64-virt.sh
@@ -2,14 +2,15 @@
 #!nix-shell --pure -p unixtools.netstat -p qemu -i bash
 
 # Check if a version argument is provided
-if [ -z "$2" ]; then
-    echo "Usage: $0 <qemu-platform> <flash_bin_path> <bao-bin-path>"
+if [ -z "$4" ]; then
+    echo "Usage: $0 <qemu-platform> <flash_bin_path> <bao-bin-path> <gic_version>"
     exit 1
 fi
 
 qemu_platform="$1"
 flash_bin_path="$2"
 bao_bin_path="$3"
+gic_version="$4"
 
 if netstat -tuln | grep ":5555 " &>/dev/null; then
     exit -1
@@ -18,7 +19,7 @@ fi
 qemu_stderr=$(mktemp)
 
 qemu-system-"$qemu_platform" -nographic \
-    -M virt,secure=on,virtualization=on,gic-version=3 \
+    -M virt,secure=on,virtualization=on,gic-version=$gic_version \
     -cpu cortex-a53 -smp 4 -m 4G \
     -bios "$flash_bin_path" \
     -device loader,file="$bao_bin_path",addr=0x50000000,force-raw=on \

--- a/framework/launch/qemu-riscv64-virt.sh
+++ b/framework/launch/qemu-riscv64-virt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure -p qemu -i bash
+#!nix-shell --pure -p unixtools.netstat -p qemu -i bash
 
 # Check if a version argument is provided
 if [ -z "$2" ]; then

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -281,9 +281,10 @@ if __name__ == '__main__':
 
     if args.gicv:
         BUILD_CMD += " --argstr GIC_VERSION " + args.gicv
-    else:
-        BUILD_CMD += " --argstr IRQC " + args.irqc + "\\ "
-        BUILD_CMD +=  "--argstr IPIC " + args.ipic
+    if args.irqc:
+        BUILD_CMD += " --argstr IRQC " + args.irqc
+    if args.ipic:
+        BUILD_CMD += " --argstr IPIC " + args.ipic
 
     print("Building with command: " + BUILD_CMD)
     res = os.system(BUILD_CMD)

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -13,6 +13,9 @@ import psutil
 import constants as cons
 import connection
 
+script_dir = os.path.dirname(os.path.abspath(__file__))
+os.chdir(script_dir)
+
 test_config = {
     'platform': '',
     'nix_file': '',

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -280,9 +280,10 @@ if __name__ == '__main__':
     BUILD_CMD += " --argstr log_level " + str(args.log_level)
 
     if args.gicv:
-        BUILD_CMD += " --argstr irq_controller " + args.gicv
+        BUILD_CMD += " --argstr GIC_VERSION " + args.gicv
     else:
-        BUILD_CMD += " --argstr irq_controller " + args.irqc + "\\ " + args.ipic
+        BUILD_CMD += " --argstr IRQC " + args.irqc + "\\ "
+        BUILD_CMD +=  "--argstr IPIC " + args.ipic
 
     print("Building with command: " + BUILD_CMD)
     res = os.system(BUILD_CMD)

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -68,7 +68,13 @@ def parse_args():
                     help="Used to define the GIC version setup for the platform",
                     default="")
     parser.add_argument("-irqc", "--irqc",
-                    help="Used to define the IRQ setup for the platform")
+                    required=False,
+                    help="Used to define the IRQ controller setup for the platform",
+                    default="")
+    parser.add_argument("-ipic", "--ipic",
+                    required=False,
+                    help="Used to define the IPIC setup for the platform",
+                    default="")
 
     input_args = parser.parse_args()
     return input_args
@@ -273,7 +279,12 @@ if __name__ == '__main__':
     BUILD_CMD += " --argstr platform " + platfrm
     BUILD_CMD += " --argstr log_level " + str(args.log_level)
 
-    print(BUILD_CMD)
+    if args.gicv:
+        BUILD_CMD += " --argstr irq_controller " + args.gicv
+    else:
+        BUILD_CMD += " --argstr irq_controller " + args.irqc + "\\ " + args.ipic
+
+    print("Building with command: " + BUILD_CMD)
     res = os.system(BUILD_CMD)
     if res==0:
         print(cons.GREEN_TEXT +

--- a/framework/test_framework.py
+++ b/framework/test_framework.py
@@ -63,6 +63,13 @@ def parse_args():
                     help="Used define the target platform",
                     default=" ")
 
+    parser.add_argument("-gicv", "--gicv",
+                    required=False,
+                    help="Used to define the GIC version setup for the platform",
+                    default="")
+    parser.add_argument("-irqc", "--irqc",
+                    help="Used to define the IRQ setup for the platform")
+
     input_args = parser.parse_args()
     return input_args
 
@@ -119,7 +126,7 @@ def get_file_path(filename):
     print(f"File '{filename}' not found in any 'result' directory.")
     sys.exit(-1)
 
-def deploy_test(platform):
+def deploy_test(platform, gicv):
     """
     Deploy a test on a specific platform.
 
@@ -130,10 +137,13 @@ def deploy_test(platform):
         arch = platform.split("-")[1]
         bao_bin_path = get_file_path("bao.bin")
         flash_bin_path = get_file_path("flash.bin")
+        gic_version = gicv.split("GICV")[1]
+
         run_cmd = "./launch/qemu-aarch64-virt.sh"
         run_cmd += " " + arch
         run_cmd += " " + flash_bin_path
         run_cmd += " " + bao_bin_path
+        run_cmd += " " + str(gic_version)
 
     elif platform in ["qemu-riscv64-virt"]:
         arch = platform.split("-")[1]
@@ -278,5 +288,6 @@ if __name__ == '__main__':
 
     move_results_to_output()
 
+    print("Interrupt Controller: " + args.gicv)
     print(cons.BLUE_TEXT + "Launching QEMU..." + cons.RESET_COLOR)
-    deploy_test(platfrm)
+    deploy_test(platfrm, args.gicv)


### PR DESCRIPTION
## PR Description
This PR introduces changes to the test framework to enable the deployment of different QEMU platforms. This allows for the deployment of the following setups:

| Architecture | QEMU Version       | Interrupt Controller            |
|--------------|--------------------|----------------------------------|
| aarch64      | qemu-aarch64-virt  | GICv2                           |
| aarch64      | qemu-aarch64-virt  | GICv3                           |
| risc-v       | qemu-riscv64-virt  | IRQC=APLIC, IPIC=IPIC_SBI       |
| risc-v       | qemu-riscv64-virt  | IRQC=PLIC, IPIC=IPIC_ACLINT     |
| risc-v       | qemu-riscv64-virt  | IRQC=PLIC, IPIC=IPIC_SBI        |
| risc-v       | qemu-riscv64-virt  | IRQC=PLIC, IPIC=IPIC_ACLINT     |

To run the framework with this feature, use the following syntax:
1. For aarch64:
```sh
python3 tests/bao-tests/framework/test_framework.py \
        -recipe <path_to_recipe> \
        -log_level <log_level> \
        -echo <echo> \
        -platform qemu-aarch64-virt \
	-gicv <gic_version>
```
2. For risc-v:
```sh
	python3 tests/bao-tests/framework/test_framework.py \
        -recipe <path_to_recipe> \
        -log_level <log_level> \
        -echo <echo> \
        -platform qemu-riscv64-virt \
	-irqc <IRQC> \
	-ipic <IPIC>
```

This PR depends on [this](https://github.com/bao-project/bao-nix/pull/14) PR in bao-nix repository.

Please provide feedback on these changes.